### PR TITLE
docs: Add Japanese TTS demo

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Change log
 v0.0.16 <2018-xx-xx>
 --------------------
 
+- `#73`_: Add Japanese TTS demo to docs and fix some typos.
 - `#72`_: Add TranscriptionDataSource for VoiceStatistics (ja) dataset
 - `#72`_: Deprecate NormalizedTranscriptionDataSource for LJSpeech dataset.
 
@@ -151,3 +152,4 @@ v0.0.1 <2017-08-14>
 .. _#68: https://github.com/r9y9/nnmnkwii/pull/68
 .. _#71: https://github.com/r9y9/nnmnkwii/pull/71
 .. _#72: https://github.com/r9y9/nnmnkwii/pull/72
+.. _#73: https://github.com/r9y9/nnmnkwii/pull/73

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ For advanced applications using the library, see :ref:`external-links-label`.
 
    nnmnkwii_gallery/notebooks/tts/01-DNN-based statistical speech synthesis (en).ipynb
    nnmnkwii_gallery/notebooks/tts/02-Bidirectional-LSTM based RNNs for speech synthesis (en).ipynb
+   nnmnkwii_gallery/notebooks/tts/02-Bidirectional-LSTM based RNNs for speech synthesis using OpenJTalk (ja).ipynb
    nnmnkwii_gallery/notebooks/vc/01-GMM voice conversion (en).ipynb
 
 .. toctree::


### PR DESCRIPTION
and fix some typos

fixes #56 

http://nbviewer.jupyter.org/github/r9y9/nnmnkwii_gallery/blob/020b78367736323b4fb6fe7ca1bed73e6ef1e94d/notebooks/tts/02-Bidirectional-LSTM%20based%20RNNs%20for%20speech%20synthesis%20using%20OpenJTalk%20%28ja%29.ipynb

![screenshot from 2018-08-20 22-06-05](https://user-images.githubusercontent.com/1220272/44342222-451f6c80-a4c5-11e8-9388-b56362f1ba5c.png)
