### PR TITLE
Read the full context label array made by PyOpenJTalk correctly in HTS.load

### DIFF
--- a/nnmnkwii/io/hts.py
+++ b/nnmnkwii/io/hts.py
@@ -181,7 +181,7 @@ J:13+9-2[2]')
         for line in lines:
             if line[0] == "#":
                 continue
-            cols = line[:-1].split()
+            cols = line.strip().split()
             if len(cols) == 3:
                 start_time, end_time, context = cols
                 start_time = int(start_time)


### PR DESCRIPTION
I think `hts.io.load` can take argument of the full context label string lines.
https://github.com/r9y9/nnmnkwii/blob/b716254aec6488adbb8401c5a90204f91fcc54be/nnmnkwii/io/hts.py#L165

This method eliminate the last character for deleting `new line`(in my understand).
https://github.com/r9y9/nnmnkwii/blob/b716254aec6488adbb8401c5a90204f91fcc54be/nnmnkwii/io/hts.py#L184

But, `lines` may have nothing new lines. (for example, PyOpenJTalk).

This PR will resolve this problem.