### PR TITLE
Fix trim_zeros_frames to trim zeros from the end

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ v0.0.19 <2019-xx-xx>
 --------------------
 
 - `#85`_: Fixed rounding error in caluculating number of frames.
+- `#87`_: Fixed :func:`nnmnkwii.preprocessing.trim_zeros_frames` issue. Support passing ``trim`` argument.
 
 v0.0.18 <2019-05-31>
 --------------------
@@ -175,3 +176,4 @@ v0.0.1 <2017-08-14>
 .. _#76: https://github.com/r9y9/nnmnkwii/pull/76
 .. _#79: https://github.com/r9y9/nnmnkwii/pull/79
 .. _#85: https://github.com/r9y9/nnmnkwii/issues/85
+.. _#87: https://github.com/r9y9/nnmnkwii/pull/87

--- a/nnmnkwii/preprocessing/generic.py
+++ b/nnmnkwii/preprocessing/generic.py
@@ -270,7 +270,7 @@ def delta_features(x, windows):
     return combined_features
 
 
-def trim_zeros_frames(x, eps=1e-7, trim=None):
+def trim_zeros_frames(x, eps=1e-7, trim='b'):
     """Remove leading and/or trailing zeros frames.
 
     Similar to :func:`numpy.trim_zeros`, trimming trailing zeros features.
@@ -290,7 +290,7 @@ def trim_zeros_frames(x, eps=1e-7, trim=None):
         >>> y = trim_zeros_frames(x)
     """
 
-    assert trim in {None, 'f', 'b', 'fb'}
+    assert trim in {'f', 'b', 'fb'}
 
     T, D = x.shape
     s = np.sum(np.abs(x), axis=1)
@@ -312,8 +312,6 @@ def trim_zeros_frames(x, eps=1e-7, trim=None):
             return x[len(x) - f:]
         else:
             return x[len(x) - f: end]
-    else:
-        return x[: len(np.trim_zeros(s))]
 
 
 def remove_zeros_frames(x, eps=1e-7):

--- a/nnmnkwii/preprocessing/generic.py
+++ b/nnmnkwii/preprocessing/generic.py
@@ -271,7 +271,7 @@ def delta_features(x, windows):
 
 
 def trim_zeros_frames(x, eps=1e-7):
-    """Remove trailling zeros frames.
+    """Remove trailing zeros frames.
 
     Similar to :func:`numpy.trim_zeros`, trimming trailing zeros features.
 
@@ -292,7 +292,7 @@ def trim_zeros_frames(x, eps=1e-7):
     T, D = x.shape
     s = np.sum(np.abs(x), axis=1)
     s[s < eps] = 0.
-    return x[: len(np.trim_zeros(s))]
+    return x[: len(np.trim_zeros(s, trim='b'))]
 
 
 def remove_zeros_frames(x, eps=1e-7):

--- a/nnmnkwii/preprocessing/generic.py
+++ b/nnmnkwii/preprocessing/generic.py
@@ -270,14 +270,15 @@ def delta_features(x, windows):
     return combined_features
 
 
-def trim_zeros_frames(x, eps=1e-7):
-    """Remove trailing zeros frames.
+def trim_zeros_frames(x, eps=1e-7, trim='fb'):
+    """Remove leading and/or trailing zeros frames.
 
     Similar to :func:`numpy.trim_zeros`, trimming trailing zeros features.
 
     Args:
         x (numpy.ndarray): Feature matrix, shape (``T x D``)
         eps (float): Values smaller than ``eps`` considered as zeros.
+        trim (string): Representing trim from where.
 
     Returns:
         numpy.ndarray: Trimmed 2d feature matrix, shape (``T' x D``)
@@ -292,7 +293,7 @@ def trim_zeros_frames(x, eps=1e-7):
     T, D = x.shape
     s = np.sum(np.abs(x), axis=1)
     s[s < eps] = 0.
-    return x[: len(np.trim_zeros(s, trim='b'))]
+    return x[: len(np.trim_zeros(s, trim=trim))]
 
 
 def remove_zeros_frames(x, eps=1e-7):

--- a/nnmnkwii/preprocessing/generic.py
+++ b/nnmnkwii/preprocessing/generic.py
@@ -270,7 +270,7 @@ def delta_features(x, windows):
     return combined_features
 
 
-def trim_zeros_frames(x, eps=1e-7, trim='fb'):
+def trim_zeros_frames(x, eps=1e-7, trim=None):
     """Remove leading and/or trailing zeros frames.
 
     Similar to :func:`numpy.trim_zeros`, trimming trailing zeros features.
@@ -290,10 +290,22 @@ def trim_zeros_frames(x, eps=1e-7, trim='fb'):
         >>> y = trim_zeros_frames(x)
     """
 
+    assert trim in {None, 'f', 'b', 'fb'}
+
     T, D = x.shape
     s = np.sum(np.abs(x), axis=1)
     s[s < eps] = 0.
-    return x[: len(np.trim_zeros(s, trim=trim))]
+
+    if trim == 'f':
+        return x[len(x) - len(np.trim_zeros(s, trim=trim)):]
+    elif trim == 'b':
+        return x[: len(np.trim_zeros(s, trim=trim))]
+    elif trim == 'fb':
+        f = len(np.trim_zeros(s, trim='f'))
+        b = len(np.trim_zeros(s, trim='b'))
+        return x[len(x) - f: b - len(x)]
+    else:
+        return x[: len(np.trim_zeros(s))]
 
 
 def remove_zeros_frames(x, eps=1e-7):

--- a/nnmnkwii/preprocessing/generic.py
+++ b/nnmnkwii/preprocessing/generic.py
@@ -299,11 +299,19 @@ def trim_zeros_frames(x, eps=1e-7, trim=None):
     if trim == 'f':
         return x[len(x) - len(np.trim_zeros(s, trim=trim)):]
     elif trim == 'b':
-        return x[: len(np.trim_zeros(s, trim=trim))]
+        end = len(np.trim_zeros(s, trim=trim)) - len(x)
+        if end == 0:
+            return x
+        else:
+            return x[: end]
     elif trim == 'fb':
         f = len(np.trim_zeros(s, trim='f'))
         b = len(np.trim_zeros(s, trim='b'))
-        return x[len(x) - f: b - len(x)]
+        end = b - len(x)
+        if end == 0:
+            return x[len(x) - f:]
+        else:
+            return x[len(x) - f: end]
     else:
         return x[: len(np.trim_zeros(s))]
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -295,6 +295,14 @@ def test_trim_zeros_frames():
     assert desired_fb.shape[1] == actual_fb.shape[1]
     np.testing.assert_array_equal(actual_fb, desired_fb)
 
+    non_zeros = np.array(((1, 1), (2, 2), (3, 3), (4, 4), (5, 5)))
+    desired_b_or_fb_non_zeros = np.array(((1, 1), (2, 2), (3, 3), (4, 4), (5, 5)))
+    actual_b = trim_zeros_frames(non_zeros, trim='b')
+    np.testing.assert_array_equal(actual_b, desired_b_or_fb_non_zeros)
+
+    actual_fb = trim_zeros_frames(non_zeros, trim='fb')
+    np.testing.assert_array_equal(actual_fb, desired_b_or_fb_non_zeros)
+
 
 def test_adjust_frame_length_divisible():
     D = 5

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -271,7 +271,7 @@ def test_trim_remove_zeros_frames():
 
 def test_trim_zeros_frames():
     arr = np.array(((0, 0), (0, 0), (1, 1), (2, 2), (0, 0)))
-    desired_default = np.array(((0, 0), (0, 0)))
+    desired_default = np.array(((0, 0), (0, 0), (1, 1), (2, 2)))
     actual_default = trim_zeros_frames(arr)
 
     assert desired_default.shape[1] == actual_default.shape[1]

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -271,11 +271,17 @@ def test_trim_remove_zeros_frames():
 
 def test_trim_zeros_frames():
     arr = np.array(((0, 0), (0, 0), (1, 1), (2, 2), (0, 0)))
-    desired = np.array(((0, 0), (0, 0), (1, 1), (2, 2)))
-    actual = trim_zeros_frames(arr)
+    desired_fb = np.array(((0, 0), (0, 0)))
+    actual_fb = trim_zeros_frames(arr)
 
-    assert desired.shape[1] == actual.shape[1]
-    np.testing.assert_array_equal(actual, desired)
+    assert desired_fb.shape[1] == actual_fb.shape[1]
+    np.testing.assert_array_equal(actual_fb, desired_fb)
+
+    desired_b = np.array(((0, 0), (0, 0), (1, 1), (2, 2)))
+    actual_b = trim_zeros_frames(arr, trim='b')
+
+    assert desired_b.shape[1] == actual_b.shape[1]
+    np.testing.assert_array_equal(actual_b, desired_b)
 
 
 def test_adjust_frame_length_divisible():

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -269,6 +269,15 @@ def test_trim_remove_zeros_frames():
         assert trimmed.shape[1] == mat.shape[1]
 
 
+def test_trim_zeros_frames():
+    arr = np.array(((0, 0), (1, 1), (1, 1), (0, 0)))
+    desired = np.array(((0, 0), (1, 1), (1, 1)))
+    actual = trim_zeros_frames(arr)
+
+    assert desired.shape[1] == actual.shape[1]
+    np.testing.assert_array_equal(actual, desired)
+
+
 def test_adjust_frame_length_divisible():
     D = 5
     T = 10

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -270,8 +270,8 @@ def test_trim_remove_zeros_frames():
 
 
 def test_trim_zeros_frames():
-    arr = np.array(((0, 0), (1, 1), (1, 1), (0, 0)))
-    desired = np.array(((0, 0), (1, 1), (1, 1)))
+    arr = np.array(((0, 0), (0, 0), (1, 1), (2, 2), (0, 0)))
+    desired = np.array(((0, 0), (0, 0), (1, 1), (2, 2)))
     actual = trim_zeros_frames(arr)
 
     assert desired.shape[1] == actual.shape[1]

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -271,17 +271,29 @@ def test_trim_remove_zeros_frames():
 
 def test_trim_zeros_frames():
     arr = np.array(((0, 0), (0, 0), (1, 1), (2, 2), (0, 0)))
-    desired_fb = np.array(((0, 0), (0, 0)))
-    actual_fb = trim_zeros_frames(arr)
+    desired_default = np.array(((0, 0), (0, 0)))
+    actual_default = trim_zeros_frames(arr)
 
-    assert desired_fb.shape[1] == actual_fb.shape[1]
-    np.testing.assert_array_equal(actual_fb, desired_fb)
+    assert desired_default.shape[1] == actual_default.shape[1]
+    np.testing.assert_array_equal(actual_default, desired_default)
 
     desired_b = np.array(((0, 0), (0, 0), (1, 1), (2, 2)))
     actual_b = trim_zeros_frames(arr, trim='b')
 
     assert desired_b.shape[1] == actual_b.shape[1]
     np.testing.assert_array_equal(actual_b, desired_b)
+
+    desired_f = np.array(((1, 1), (2, 2), (0, 0)))
+    actual_f = trim_zeros_frames(arr, trim='f')
+
+    assert desired_f.shape[1] == actual_f.shape[1]
+    np.testing.assert_array_equal(actual_f, desired_f)
+
+    desired_fb = np.array(((1, 1), (2, 2)))
+    actual_fb = trim_zeros_frames(arr, trim='fb')
+
+    assert desired_fb.shape[1] == actual_fb.shape[1]
+    np.testing.assert_array_equal(actual_fb, desired_fb)
 
 
 def test_adjust_frame_length_divisible():


### PR DESCRIPTION
Docs of trim_zeros_frames says `Remove trailing zeros frames`.
But it behaves removing both front and back zero frames because of lack of `np.trim_zeros` 's `trim` option.

expected
```py
arr = np.array(((0, 0), (1, 1), (2, 2), (0, 0)))
actual = trim_zeros_frames(arr)
# np.array(((0, 0), (1, 1), (2, 2)))
```

actual
```py
arr = np.array(((0, 0), (1, 1), (2, 2), (0, 0)))
actual = trim_zeros_frames(arr)
# np.array(((0, 0), (1, 1)))
```

So I thought that it's better to set option `trim='b'`.