### PR TITLE
Fix label time overflow on environment which size of np.int is 4bytes.

### DIFF
--- a/nnmnkwii/io/hts.py
+++ b/nnmnkwii/io/hts.py
@@ -132,8 +132,8 @@ J:13+9-2[2]')
 
     def round_(self):
         s = self.frame_shift
-        self.start_times = list(np.round(np.asarray(self.start_times) / s).astype(np.int) * s)
-        self.end_times = list(np.round(np.asarray(self.end_times) / s).astype(np.int) * s)
+        self.start_times = list(np.round(np.asarray(self.start_times) / s).astype(np.int64) * s)
+        self.end_times = list(np.round(np.asarray(self.end_times) / s).astype(np.int64) * s)
         return self
 
     def append(self, label, strict=True):
@@ -179,10 +179,10 @@ J:13+9-2[2]')
 
         # Unwrap state-axis
         end_times = offset + np.cumsum(
-            durations.reshape(-1, 1) * frame_shift).astype(np.int)
+            durations.reshape(-1, 1) * frame_shift).astype(np.int64)
         if len(end_times) != len(self.end_times):
             raise RuntimeError("Unexpected input, maybe")
-        start_times = np.hstack((offset, end_times[:-1])).astype(np.int)
+        start_times = np.hstack((offset, end_times[:-1])).astype(np.int64)
         self.start_times, self.end_times = start_times, end_times
 
     def load(self, path=None, lines=None):
@@ -273,7 +273,7 @@ J:13+9-2[2]')
         s = start_times[indices] // frame_shift
         e = end_times[indices] // frame_shift
         return np.unique(np.concatenate(
-            [np.arange(a, b) for (a, b) in zip(s, e)], axis=0)).astype(np.int)
+            [np.arange(a, b) for (a, b) in zip(s, e)], axis=0)).astype(np.int64)
 
     def is_state_alignment_label(self):
         return self.contexts[0][-1] == ']' and self.contexts[0][-3] == '['


### PR DESCRIPTION
On environment which size of np.int is 4 bytes, HTSLabelFile.round_() may return negative start_time or end_time due to integer overflow.  Replacing np.int with np.int64 solves this problem.

P.S. I have no idea why the size of np.int is 4 bytes even though anaconda's python is 64bit.
```
$ winpty python
Python 3.6.10 |Anaconda, Inc.| (default, May  7 2020, 19:46:08) [MSC v.1916 64 b
it (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> print(sys.maxsize)
9223372036854775807
>>> from nnmnkwii.io import hts
>>> label_path="large_time_example.lab"
>>> labels = hts.load(label_path)
>>> print(labels)
2135126050 2137647058 c@m^a-d+e=i_00%00^00_00~00-1!2[xx$1]xx/A:2-1-1@JPN~0/B:2_1
_1@JPN|0/C:1+1+1@JPN&0/D:A3!9#0$4/4%119|1&25;12-xx/E:B3]11^0=4/4~119!1@25#12+xx]
6$1|17[2&84]12=87^13~10#12_27;47$132&228%36[64|0]0-n^xx+xx~xx=xx@xx$xx!xx%xx#xx|
xx|xx-xx&xx&xx+xx[xx;xx]xx;xx~xx~xx^xx^xx@xx[xx#xx=xx!xx~m2+p2!xx^xx/F:Db4#1#0-4
/4$119$1+100%48;xx/G:8_8/H:21_21/I:25_25/J:3~3@45
2135126050 2137647058 v@a^d-e+i=s_00%00^00_00~00-2!1[xx$xx]xx/A:2-1-1@JPN~0/B:2_
1_1@JPN|0/C:1+1+1@JPN&0/D:A3!9#0$4/4%119|1&25;12-xx/E:B3]11^0=4/4~119!1@25#12+xx
]6$1|17[2&84]12=87^13~10#12_27;47$132&228%36[64|0]0-n^xx+xx~xx=xx@xx$xx!xx%xx#xx
|xx|xx-xx&xx&xx+xx[xx;xx]xx;xx~xx~xx^xx^xx@xx[xx#xx=xx!xx~m2+p2!xx^xx/F:Db4#1#0-
4/4$119$1+100%48;xx/G:8_8/H:21_21/I:25_25/J:3~3@45
2137647058 2147731092 v@d^e-i+s=o_00%00^00_00~00-1!1[xx$xx]xx/A:2-1-1@JPN~0/B:1_
1_1@JPN|0/C:2+1+1@JPN&0/D:B3!11#0$4/4%119|1&25;12-xx/E:Db4]1^0=4/4~119!1@100#48+
xx]1$5|0[20&0]96=0^100~11#11_30;45$144&216%40[60|0]0-n^xx+xx~xx=xx@xx$xx!xx%xx#x
x|xx|xx-xx&xx&xx+xx[xx;xx]xx;xx~xx~xx^xx^xx@xx[xx#xx=xx!xx~m2+m7!xx^xx/F:Gb3#6#0
-4/4$119$1+25%12;xx/G:8_8/H:21_21/I:25_25/J:3~3@45
2147731092 2150252100 c@e^i-s+o=r_00%00^00_00~00-1!2[xx$1]xx/A:1-1-1@JPN~0/B:2_1
_1@JPN|0/C:2+1+1@JPN&0/D:Db4!1#0$4/4%119|1&100;48-xx/E:Gb3]6^0=4/4~119!1@25#12+x
x]2$4|10[10&48]48=50^50~12#10_40;35$192&168%53[47|0]0-n^xx+xx~xx=xx@xx$xx!xx%xx#
xx|xx|xx-xx&xx&xx+xx[xx;xx]xx;xx~xx~xx^xx^xx@xx[xx#xx=xx!xx~p7+p2!xx^xx/F:Ab3#8#
0-4/4$119$1+25%12;xx/G:8_8/H:21_21/I:25_25/J:3~3@45
>>> print(labels.round_())
2135150000 2137650000 c@m^a-d+e=i_00%00^00_00~00-1!2[xx$1]xx/A:2-1-1@JPN~0/B:2_1
_1@JPN|0/C:1+1+1@JPN&0/D:A3!9#0$4/4%119|1&25;12-xx/E:B3]11^0=4/4~119!1@25#12+xx]
6$1|17[2&84]12=87^13~10#12_27;47$132&228%36[64|0]0-n^xx+xx~xx=xx@xx$xx!xx%xx#xx|
xx|xx-xx&xx&xx+xx[xx;xx]xx;xx~xx~xx^xx^xx@xx[xx#xx=xx!xx~m2+p2!xx^xx/F:Db4#1#0-4
/4$119$1+100%48;xx/G:8_8/H:21_21/I:25_25/J:3~3@45
2135150000 2137650000 v@a^d-e+i=s_00%00^00_00~00-2!1[xx$xx]xx/A:2-1-1@JPN~0/B:2_
1_1@JPN|0/C:1+1+1@JPN&0/D:A3!9#0$4/4%119|1&25;12-xx/E:B3]11^0=4/4~119!1@25#12+xx
]6$1|17[2&84]12=87^13~10#12_27;47$132&228%36[64|0]0-n^xx+xx~xx=xx@xx$xx!xx%xx#xx
|xx|xx-xx&xx&xx+xx[xx;xx]xx;xx~xx~xx^xx^xx@xx[xx#xx=xx!xx~m2+p2!xx^xx/F:Db4#1#0-
4/4$119$1+100%48;xx/G:8_8/H:21_21/I:25_25/J:3~3@45
2137650000 -2147217296 v@d^e-i+s=o_00%00^00_00~00-1!1[xx$xx]xx/A:2-1-1@JPN~0/B:1
_1_1@JPN|0/C:2+1+1@JPN&0/D:B3!11#0$4/4%119|1&25;12-xx/E:Db4]1^0=4/4~119!1@100#48
+xx]1$5|0[20&0]96=0^100~11#11_30;45$144&216%40[60|0]0-n^xx+xx~xx=xx@xx$xx!xx%xx#
xx|xx|xx-xx&xx&xx+xx[xx;xx]xx;xx~xx~xx^xx^xx@xx[xx#xx=xx!xx~m2+m7!xx^xx/F:Gb3#6#
0-4/4$119$1+25%12;xx/G:8_8/H:21_21/I:25_25/J:3~3@45
-2147217296 -2144717296 c@e^i-s+o=r_00%00^00_00~00-1!2[xx$1]xx/A:1-1-1@JPN~0/B:2
_1_1@JPN|0/C:2+1+1@JPN&0/D:Db4!1#0$4/4%119|1&100;48-xx/E:Gb3]6^0=4/4~119!1@25#12
+xx]2$4|10[10&48]48=50^50~12#10_40;35$192&168%53[47|0]0-n^xx+xx~xx=xx@xx$xx!xx%x
x#xx|xx|xx-xx&xx&xx+xx[xx;xx]xx;xx~xx~xx^xx^xx@xx[xx#xx=xx!xx~p7+p2!xx^xx/F:Ab3#
8#0-4/4$119$1+25%12;xx/G:8_8/H:21_21/I:25_25/J:3~3@45
```

