### PR TITLE
io: fix bug of handling pitch diff in the SVS full context format

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ v0.0.22 <2020-xx-xx>
 --------------------
 
 - `#108`_: Fix label time overflow on environment which size of np.int is 4bytes
-
+- `#109`_: io: fix bug of handling pitch diff in the SVS full context format
 
 v0.0.21 <2020-08-13>
 --------------------
@@ -208,3 +208,4 @@ v0.0.1 <2017-08-14>
 .. _#99: https://github.com/r9y9/nnmnkwii/issues/99
 .. _#101: https://github.com/r9y9/nnmnkwii/pull/101
 .. _#108: https://github.com/r9y9/nnmnkwii/pull/108
+.. _#109: https://github.com/r9y9/nnmnkwii/pull/109

--- a/nnmnkwii/frontend/merlin.py
+++ b/nnmnkwii/frontend/merlin.py
@@ -158,6 +158,11 @@ def pattern_matching_continous_position(continuous_dict, label):
             continuous_value = ms.group(1)
             if continuous_value in NOTE_MAPPING:
                 continuous_value = NOTE_MAPPING[continuous_value]
+            if isinstance(continuous_value, str):
+                if continuous_value.startswith("p"):
+                    continuous_value = int(continuous_value[1:])
+                elif continuous_value.startswith("m"):
+                    continuous_value = -int(continuous_value[1:])
 
         lab_continuous_vector[0, i] = continuous_value
 

--- a/nnmnkwii/io/hts.py
+++ b/nnmnkwii/io/hts.py
@@ -325,7 +325,7 @@ def load(path=None, lines=None):
     return labels.load(path, lines)
 
 
-def wildcards2regex(question, convert_number_pattern=False, convert_note_pattern=True):
+def wildcards2regex(question, convert_number_pattern=False, convert_svs_pattern=True):
     """subphone_features
     Convert HTK-style question into regular expression for searching labels.
     If convert_number_pattern, keep the following sequences unescaped for
@@ -352,14 +352,17 @@ def wildcards2regex(question, convert_number_pattern=False, convert_note_pattern
         question = question.replace('\\(\\\\d\\+\\)', '(\d+)')
         question = question.replace(
             '\\(\\[\\\\d\\\\\\.\\]\\+\\)', '([\d\.]+)')
-    if convert_note_pattern:
+    # NOTE: singing voice synthesis specific handling
+    if convert_svs_pattern:
         question = question.replace(
             '\\(\\[A\\-Z\\]\\[b\\]\\?\\[0\\-9\\]\\+\\)', '([A-Z][b]?[0-9]+)')
         question = question.replace('\\(\\\\NOTE\\)', '([A-Z][b]?[0-9]+)')
+        question = question.replace('\\(\\[pm\\]\\\\d\\+\\)', '([pm]\d+)')
+
     return question
 
 
-def load_question_set(qs_file_name, append_hat_for_LL=True):
+def load_question_set(qs_file_name, append_hat_for_LL=True, convert_svs_pattern=True):
     """Load HTS-style question and convert it to binary/continuous feature
     extraction regexes.
 
@@ -371,6 +374,7 @@ def load_question_set(qs_file_name, append_hat_for_LL=True):
             Note that the most left context is assumed to be phoneme identity
             before the previous phoneme (i.e. LL-xx). This parameter should be False
             for the HTS-demo_NIT-SONG070-F001 demo.
+        convert_svs_pattern (bool): Convert SVS specific patterns.
 
     Returns:
         (binary_dict, continuous_dict): Binary/continuous feature extraction

--- a/tests/data/test_jp_svs.hed
+++ b/tests/data/test_jp_svs.hed
@@ -1,2 +1,3 @@
 QS "L-Phone_Yuusei_Boin"           {*^a-*,*^i-*,*^u-*,*^e-*,*^o-*}
 CQS "e1" {/E:(\NOTE)]}
+CQS "e57" {~([pm]\d+)+}

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -7,6 +7,7 @@ from nnmnkwii.util import example_question_file
 import re
 from nose.tools import raises
 
+
 DATA_DIR = join(dirname(__file__), "data")
 
 
@@ -88,11 +89,11 @@ QS "L-Phone_Yuusei_Boin"           {*^a-*,*^i-*,*^u-*,*^e-*,*^o-*}
 CQS "e1" {/E:(\\NOTE)]}
     """
     binary_dict, continuous_dict = hts.load_question_set(
-        join(DATA_DIR, "test_jp_svs.hed"), append_hat_for_LL=False)
+        join(DATA_DIR, "test_jp_svs.hed"), append_hat_for_LL=False, convert_svs_pattern=True)
     input_phone_label = join(DATA_DIR, "song070_f00001_063.lab")
     labels = hts.load(input_phone_label)
     feats = fe.linguistic_features(labels, binary_dict, continuous_dict)
-    assert feats.shape == (74, 2)
+    assert feats.shape == (74, 3)
 
     # CQS e1: get the current MIDI number
     C_e1 = continuous_dict[0]
@@ -101,6 +102,17 @@ CQS "e1" {/E:(\\NOTE)]}
         if C_e1.search(context) is not None:
             from nnmnkwii.frontend import NOTE_MAPPING
             assert NOTE_MAPPING[C_e1.findall(context)[0]] == feats[idx, 1]
+
+    # CQS e57: get pitch diff
+    # In contrast to other continous features, the pitch diff has a prefix "m" or "p"
+    # to indiecate th sign of numbers.
+    C_e57 = continuous_dict[1]
+    for idx, lab in enumerate(labels):
+        context = lab[-1]
+        if "~p2+" in context:
+            assert C_e57.search(context).group(1) == "p2"
+        if "~m2+" in context:
+            assert C_e57.search(context).group(1) == "m2"
 
 
 def test_state_alignment_label_file():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -111,8 +111,10 @@ CQS "e1" {/E:(\\NOTE)]}
         context = lab[-1]
         if "~p2+" in context:
             assert C_e57.search(context).group(1) == "p2"
+            assert feats[idx, 2] == 2
         if "~m2+" in context:
             assert C_e57.search(context).group(1) == "m2"
+            assert feats[idx, 2] == -2
 
 
 def test_state_alignment_label_file():


### PR DESCRIPTION
Different from other continuous features, the pitch diff has a prefix "m" or "p" to indicate the sign of numbers.
Add special handling for this situation.