### PR TITLE
Replace  pkg_resources  to  importlib.resources 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
           - os: windows-latest
             python-version: 3.9
           - os: windows-latest
-            python-version: 3.12
+            python-version: '3.12'
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,18 +19,19 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: 3.8
-          - os: ubuntu-latest
             python-version: 3.9
           - os: ubuntu-latest
             python-version: '3.10'
           - os: ubuntu-latest
             python-version: '3.11'
+          - os: ubuntu-latest
+            python-version: '3.12'
           - os: macos-latest
             python-version: 3.9
           - os: windows-latest
             python-version: 3.9
-
+          - os: windows-latest
+            python-version: 3.12
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,8 +30,6 @@ jobs:
             python-version: 3.9
           - os: windows-latest
             python-version: 3.9
-          - os: windows-latest
-            python-version: '3.12'
     steps:
     - uses: actions/checkout@v2
       with:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # nnmnkwii documentation build configuration file, created by
 # sphinx-quickstart on Sat Jul 29 16:55:09 2017.
@@ -23,10 +22,9 @@
 
 
 import os
+from importlib.metadata import version  # Python 3.8+
 
-import pkg_resources
-
-__version__ = pkg_resources.get_distribution("nnmnkwii").version
+__version__ = version("nnmnkwii")
 
 ON_RTD = os.environ.get("READTHEDOCS", None) == "True"
 
@@ -85,7 +83,8 @@ if not ON_RTD:
     if use_matplotlib_plot_directive:
         extensions.append("matplotlib.sphinxext.plot_directive")
     else:
-        raise RuntimeError("You need a recent enough version of matplotlib")
+        msg = "You need a recent enough version of matplotlib"
+        raise RuntimeError(msg)
 
 # ------------------------------------------------------------------------------
 # Plot

--- a/nnmnkwii/util/files.py
+++ b/nnmnkwii/util/files.py
@@ -29,7 +29,9 @@ def example_label_file(*, phone_level: bool = False) -> str:
     """
     name = "arctic_a0009"
     suffix = "phone" if phone_level else "state"
-    label_path = resources.files(__name__) / "_example_data" / f"{name}_{suffix}.lab"
+    label_path = (
+        resources.files("nnmnkwii.util") / "_example_data" / f"{name}_{suffix}.lab"
+    )
     return str(label_path)
 
 
@@ -48,7 +50,7 @@ def example_audio_file() -> str:
         >>> fs, x = wavfile.read(example_audio_file())
     """
     name = "arctic_a0009"
-    wav_path = resources.files(__name__) / "_example_data" / f"{name}.wav"
+    wav_path = resources.files("nnmnkwii.util") / "_example_data" / f"{name}.wav"
     return str(wav_path)
 
 
@@ -68,7 +70,7 @@ def example_question_file() -> str:
         >>> binary_dict, numeric_dict = hts.load_question_set(example_question_file())
     """
     name = "questions-radio_dnn_416"
-    hed_path = resources.files(__name__) / "_example_data" / f"{name}.hed"
+    hed_path = resources.files("nnmnkwii.util") / "_example_data" / f"{name}.hed"
     return str(hed_path)
 
 
@@ -85,7 +87,7 @@ class BinaryFileDataSource(FileDataSource):
 
 class ExampleSLTArcticFileDataSource(BinaryFileDataSource):
     SLT_DEMO_DATA_ROOT = (
-        resources.files(__name__) / "_example_data" / "slt_arctic_demo_data"
+        resources.files("nnmnkwii.util") / "_example_data" / "slt_arctic_demo_data"
     )
 
     mgc_dim = 75

--- a/nnmnkwii/util/files.py
+++ b/nnmnkwii/util/files.py
@@ -1,12 +1,13 @@
 from glob import glob
+from importlib import resources
 from os.path import join
 
 import numpy as np
-import pkg_resources
+
 from nnmnkwii.datasets import FileDataSource
 
 
-def example_label_file(phone_level=False):
+def example_label_file(*, phone_level: bool = False) -> str:
     """Get path of example HTS-style full-context lable file.
 
     Corresponding audio file can be accessed by
@@ -28,14 +29,12 @@ def example_label_file(phone_level=False):
         >>> labels = hts.load(example_label_file())
     """
     name = "arctic_a0009"
-    label_path = pkg_resources.resource_filename(
-        __name__,
-        "_example_data/{}_{}.lab".format(name, "phone" if phone_level else "state"),
-    )
-    return label_path
+    suffix = "phone" if phone_level else "state"
+    label_path = resources.files(__name__) / "_example_data" / f"{name}_{suffix}.lab"
+    return str(label_path)
 
 
-def example_audio_file():
+def example_audio_file() -> str:
     """Get path of audio file.
 
     Returns:
@@ -50,13 +49,11 @@ def example_audio_file():
         >>> fs, x = wavfile.read(example_audio_file())
     """
     name = "arctic_a0009"
-    wav_path = pkg_resources.resource_filename(
-        __name__, "_example_data/{}.wav".format(name)
-    )
-    return wav_path
+    wav_path = resources.files(__name__) / "_example_data" / f"{name}.wav"
+    return str(wav_path)
 
 
-def example_question_file():
+def example_question_file() -> str:
     """Get path of example question file.
 
     The question file was taken from Merlin_.
@@ -71,9 +68,9 @@ def example_question_file():
         >>> from nnmnkwii.io import hts
         >>> binary_dict, numeric_dict = hts.load_question_set(example_question_file())
     """
-    return pkg_resources.resource_filename(
-        __name__, "_example_data/questions-radio_dnn_416.hed"
-    )
+    name = "questions-radio_dnn_416"
+    hed_path = resources.files(__name__) / "_example_data" / f"{name}.hed"
+    return str(hed_path)
 
 
 class BinaryFileDataSource(FileDataSource):
@@ -88,8 +85,8 @@ class BinaryFileDataSource(FileDataSource):
 
 
 class ExampleSLTArcticFileDataSource(BinaryFileDataSource):
-    SLT_DEMO_DATA_ROOT = pkg_resources.resource_filename(
-        __name__, "_example_data/slt_arctic_demo_data"
+    SLT_DEMO_DATA_ROOT = (
+        resources.files(__name__) / "_example_data" / "slt_arctic_demo_data"
     )
 
     mgc_dim = 75
@@ -115,9 +112,7 @@ class ExampleSLTArcticFileDataSource(BinaryFileDataSource):
     ]
 
     def __init__(self, directory):
-        super(ExampleSLTArcticFileDataSource, self).__init__(
-            join(self.SLT_DEMO_DATA_ROOT, directory)
-        )
+        super().__init__(self.SLT_DEMO_DATA_ROOT / directory)
 
 
 def example_file_data_sources_for_duration_model():

--- a/nnmnkwii/util/files.py
+++ b/nnmnkwii/util/files.py
@@ -3,7 +3,6 @@ from importlib import resources
 from os.path import join
 
 import numpy as np
-
 from nnmnkwii.datasets import FileDataSource
 
 

--- a/tests/bandmat/test_linalg.py
+++ b/tests/bandmat/test_linalg.py
@@ -12,9 +12,6 @@ import unittest
 import numpy as np
 import numpy.linalg as la
 import scipy.linalg as sla
-from numpy.random import randint, randn
-from test_core import gen_BandMat
-
 from nnmnkwii.paramgen import _bandmat as bm
 from nnmnkwii.paramgen._bandmat import full as fl
 from nnmnkwii.paramgen._bandmat import linalg as bla
@@ -22,6 +19,8 @@ from nnmnkwii.paramgen._bandmat.testhelp import (
     assert_allclose,
     randomize_extra_entries_bm,
 )
+from numpy.random import randint, randn
+from test_core import gen_BandMat
 
 
 def rand_bool():

--- a/tests/bandmat/test_linalg.py
+++ b/tests/bandmat/test_linalg.py
@@ -12,6 +12,9 @@ import unittest
 import numpy as np
 import numpy.linalg as la
 import scipy.linalg as sla
+from numpy.random import randint, randn
+from test_core import gen_BandMat
+
 from nnmnkwii.paramgen import _bandmat as bm
 from nnmnkwii.paramgen._bandmat import full as fl
 from nnmnkwii.paramgen._bandmat import linalg as bla
@@ -19,8 +22,6 @@ from nnmnkwii.paramgen._bandmat.testhelp import (
     assert_allclose,
     randomize_extra_entries_bm,
 )
-from numpy.random import randint, randn
-from test_core import gen_BandMat
 
 
 def rand_bool():
@@ -139,7 +140,7 @@ class TestLinAlg(unittest.TestCase):
             except la.LinAlgError as e:
                 # First part of the message is e.g. "2-th leading minor".
                 msgRe = r"^" + re.escape(str(e)[:15]) + r".*not positive definite$"
-                with self.assertRaisesRegexp(la.LinAlgError, msgRe):
+                with self.assertRaisesRegex(la.LinAlgError, msgRe):
                     sla.cholesky(mat_bm.full(), lower=lower)
             else:
                 assert np.shape(chol_data) == (depth + 1, size)
@@ -180,7 +181,7 @@ class TestLinAlg(unittest.TestCase):
             if badFrame is not None:
                 msg = "singular matrix: resolution failed at diagonal %d" % badFrame
                 msgRe = "^" + re.escape(msg) + "$"
-                with self.assertRaisesRegexp(la.LinAlgError, msgRe):
+                with self.assertRaisesRegex(la.LinAlgError, msgRe):
                     bla._solve_triangular_banded(
                         chol_data,
                         b_arg,
@@ -188,7 +189,7 @@ class TestLinAlg(unittest.TestCase):
                         lower=lower,
                         overwrite_b=overwrite_b,
                     )
-                with self.assertRaisesRegexp(la.LinAlgError, msgRe):
+                with self.assertRaisesRegex(la.LinAlgError, msgRe):
                     sla.solve_triangular(chol_full, b, trans=transposed, lower=lower)
             else:
                 x = bla._solve_triangular_banded(


### PR DESCRIPTION
Fix #135 
- Replaced the deprecated package `pkg_resources` to `importlib.resources`, in order to use nnmnkwii even after 2025-11-30 with the latest setuptools>=81.
  - **THIS CHANGE MAKE nnmnkwii INCOMPATIBLE WITH Python<=3.8,** because `importlib.resources.files` is available only in Python>=3.9.
- Fix typo `assertRaisesRegexp` -> `assertRaisesRegex`
- Tested on Python 3.12.